### PR TITLE
storage: add interface storer.MergeStorer

### DIFF
--- a/plumbing/format/merge/merge.go
+++ b/plumbing/format/merge/merge.go
@@ -1,0 +1,12 @@
+package merge
+
+// Mode is the merge mode (e.g. "no-ff") given by the file MERGE_MODE in the
+// .git folder
+type Mode int
+
+const (
+	// Default when MERGE_MODE is empty
+	Default Mode = iota
+	// NoFF when MERGE_MODE is no-ff
+	NoFF
+)

--- a/plumbing/storer/merge.go
+++ b/plumbing/storer/merge.go
@@ -1,0 +1,15 @@
+package storer
+
+import (
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/merge"
+)
+
+// MergeStorer access the merge information
+// In .git folder, that's the files
+// MERGE_HEAD, MERGE_MODE, MERGE_MSG
+type MergeStorer interface {
+	MergeHead() plumbing.Hash
+	MergeMode() merge.Mode
+	MergeMsg() string
+}

--- a/repository.go
+++ b/repository.go
@@ -1552,3 +1552,8 @@ func (r *Repository) createNewObjectPack(cfg *RepackConfig) (h plumbing.Hash, er
 
 	return h, err
 }
+
+// IsMergeInProgress returns true is a merge is in progress, else false
+func (r *Repository) IsMergeInProgress() bool {
+	return r.Storer.MergeHead() != plumbing.ZeroHash
+}

--- a/storage/filesystem/dotgit/dotgit.go
+++ b/storage/filesystem/dotgit/dotgit.go
@@ -14,6 +14,7 @@ import (
 
 	"gopkg.in/src-d/go-billy.v4/osfs"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/merge"
 	"gopkg.in/src-d/go-git.v4/storage"
 	"gopkg.in/src-d/go-git.v4/utils/ioutil"
 
@@ -30,6 +31,9 @@ const (
 	objectsPath    = "objects"
 	packPath       = "pack"
 	refsPath       = "refs"
+	mergeHeadPath  = "MERGE_HEAD"
+	mergeModePath  = "MERGE_MODE"
+	mergeMsgPath   = "MERGE_MSG"
 
 	tmpPackedRefsPrefix = "._packed-refs"
 
@@ -1073,6 +1077,56 @@ func (d *DotGit) Alternates() ([]*DotGit, error) {
 // Fs returns the underlying filesystem of the DotGit folder.
 func (d *DotGit) Fs() billy.Filesystem {
 	return d.fs
+}
+
+// MergeHead returns the hash of the merge head from the MERGE_HEAD file
+func (d *DotGit) MergeHead() (plumbing.Hash, error) {
+	file, err := d.localfs.Open(mergeHeadPath)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	var value []byte
+	value, err = stdioutil.ReadAll(file)
+	if err != nil {
+		return plumbing.ZeroHash, err
+	}
+
+	return plumbing.NewHash(string(value)), nil
+}
+
+// MergeMode returns the merge mode given by the MERGE_MODE file
+func (d *DotGit) MergeMode() (merge.Mode, error) {
+	var mode merge.Mode
+	file, err := d.localfs.Open(mergeModePath)
+	if err != nil {
+		return mode, err
+	}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		switch scanner.Text() {
+		case "no-ff":
+			mode = merge.NoFF
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return mode, err
+	}
+	return mode, nil
+}
+
+// MergeMsg returns the text given by the MERGE_MSG file
+func (d *DotGit) MergeMsg() (string, error) {
+	file, err := d.localfs.Open(mergeMsgPath)
+	if err != nil {
+		return "", err
+	}
+	var msg []byte
+	msg, err = stdioutil.ReadAll(file)
+	if err != nil {
+		return "", err
+	}
+	return string(msg), nil
 }
 
 func isHex(s string) bool {

--- a/storage/filesystem/dotgit/dotgit_test.go
+++ b/storage/filesystem/dotgit/dotgit_test.go
@@ -11,6 +11,7 @@ import (
 
 	"gopkg.in/src-d/go-billy.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/merge"
 
 	. "gopkg.in/check.v1"
 	"gopkg.in/src-d/go-billy.v4/osfs"
@@ -810,6 +811,40 @@ func (s *SuiteDotGit) TestAlternates(c *C) {
 		expectedPath = filepath.Join(resolvedPath, "rep2", ".git")
 	}
 	c.Assert(dotgits[1].fs.Root(), Equals, expectedPath)
+}
+
+func (s *SuiteDotGit) TestMergeHead(c *C) {
+	fs := fixtures.Basic().ByTag("merge-conflict").One().DotGit()
+	dotgit := New(fs)
+
+	want := plumbing.NewHash("f72835db2eeacb70969ef2164c30a2613c40609c")
+	got, err := dotgit.MergeHead()
+	c.Assert(err, IsNil)
+	c.Assert(got, Equals, want)
+}
+
+func (s *SuiteDotGit) TestMergeMode(c *C) {
+	fs := fixtures.Basic().ByTag("merge-conflict").One().DotGit()
+	dotgit := New(fs)
+
+	want := merge.Default
+	got, err := dotgit.MergeMode()
+	c.Assert(err, IsNil)
+	c.Assert(got, Equals, want)
+}
+
+func (s *SuiteDotGit) TestMergeMsg(c *C) {
+	fs := fixtures.Basic().ByTag("merge-conflict").One().DotGit()
+	dotgit := New(fs)
+
+	want := "Merge branch 'master' of https://github.com/tcard/git-fixture\n\n"
+	want += "# Conflicts:\n"
+	want += "#\tgo/example.go\n"
+	want += "#\thaskal/haskal.hs\n"
+
+	got, err := dotgit.MergeMsg()
+	c.Assert(err, IsNil)
+	c.Assert(got, Equals, want)
 }
 
 type norwfs struct {

--- a/storage/filesystem/merge.go
+++ b/storage/filesystem/merge.go
@@ -1,0 +1,35 @@
+package filesystem
+
+import (
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/merge"
+	"gopkg.in/src-d/go-git.v4/storage/filesystem/dotgit"
+)
+
+// MergeStorage gives the content of the file
+// MERGE_HEAD, MERGE_MODE, MERGE_MSG in the
+// .git folder during a merge
+type MergeStorage struct {
+	dir  *dotgit.DotGit
+	head plumbing.Hash
+	mode merge.Mode
+	msg  string
+}
+
+// MergeHead returns the content of MERGE_HEAD
+func (m *MergeStorage) MergeHead() plumbing.Hash {
+	head, _ := m.dir.MergeHead()
+	return head
+}
+
+// MergeMode returns the content of MERGE_MODE
+func (m *MergeStorage) MergeMode() merge.Mode {
+	mode, _ := m.dir.MergeMode()
+	return mode
+}
+
+// MergeMsg returns the content of MERGE_MSG
+func (m *MergeStorage) MergeMsg() string {
+	msg, _ := m.dir.MergeMsg()
+	return msg
+}

--- a/storage/filesystem/storage.go
+++ b/storage/filesystem/storage.go
@@ -21,6 +21,7 @@ type Storage struct {
 	ShallowStorage
 	ConfigStorage
 	ModuleStorage
+	MergeStorage
 }
 
 // Options holds configuration for the storage.
@@ -59,6 +60,7 @@ func NewStorageWithOptions(fs billy.Filesystem, cache cache.Object, ops Options)
 		ShallowStorage:   ShallowStorage{dir: dir},
 		ConfigStorage:    ConfigStorage{dir: dir},
 		ModuleStorage:    ModuleStorage{dir: dir},
+		MergeStorage:     MergeStorage{dir: dir},
 	}
 }
 

--- a/storage/memory/storage.go
+++ b/storage/memory/storage.go
@@ -8,6 +8,7 @@ import (
 	"gopkg.in/src-d/go-git.v4/config"
 	"gopkg.in/src-d/go-git.v4/plumbing"
 	"gopkg.in/src-d/go-git.v4/plumbing/format/index"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/merge"
 	"gopkg.in/src-d/go-git.v4/plumbing/storer"
 	"gopkg.in/src-d/go-git.v4/storage"
 )
@@ -25,6 +26,7 @@ type Storage struct {
 	IndexStorage
 	ReferenceStorage
 	ModuleStorage
+	MergeStorage
 }
 
 // NewStorage returns a new Storage base on memory
@@ -41,6 +43,7 @@ func NewStorage() *Storage {
 			Tags:    make(map[plumbing.Hash]plumbing.EncodedObject),
 		},
 		ModuleStorage: make(ModuleStorage),
+		MergeStorage:  MergeStorage{},
 	}
 }
 
@@ -317,4 +320,28 @@ func (s ModuleStorage) Module(name string) (storage.Storer, error) {
 	s[name] = m
 
 	return m, nil
+}
+
+type MergeStorage struct {
+	Head plumbing.Hash
+	Mode merge.Mode
+	Msg  string
+}
+
+// MergeHead returns the hash of the merge
+// Not implemented
+func (m MergeStorage) MergeHead() plumbing.Hash {
+	return plumbing.ZeroHash
+}
+
+// MergeMode returns the mode of the merge, e.g. no-ff
+// Not implemented
+func (m MergeStorage) MergeMode() merge.Mode {
+	return merge.Default
+}
+
+// MergeMsg returns the message of the merge
+// Not implemented
+func (m MergeStorage) MergeMsg() string {
+	return ""
 }

--- a/storage/storer.go
+++ b/storage/storer.go
@@ -18,6 +18,7 @@ type Storer interface {
 	storer.ReferenceStorer
 	storer.ShallowStorer
 	storer.IndexStorer
+	storer.MergeStorer
 	config.ConfigStorer
 	ModuleStorer
 }

--- a/storage/transactional/merge.go
+++ b/storage/transactional/merge.go
@@ -1,0 +1,33 @@
+package transactional
+
+import (
+	"gopkg.in/src-d/go-git.v4/plumbing"
+	"gopkg.in/src-d/go-git.v4/plumbing/format/merge"
+	"gopkg.in/src-d/go-git.v4/plumbing/storer"
+)
+
+type MergeStorage struct {
+	storer.MergeStorer
+	temporal storer.MergeStorer
+}
+
+// NewMergeStorage returns a new MergeStorer based on a base storer and a
+// temporal storer.
+func NewMergeStorage(s, temporal storer.MergeStorer) *MergeStorage {
+	return &MergeStorage{MergeStorer: s, temporal: temporal}
+}
+
+// MergeHead returns the hash of the merge
+func (m MergeStorage) MergeHead() plumbing.Hash {
+	return m.MergeStorer.MergeHead()
+}
+
+// MergeMode returns the mode of the merge, e.g. no-ff
+func (m MergeStorage) MergeMode() merge.Mode {
+	return m.MergeStorer.MergeMode()
+}
+
+// MergeMsg returns the message of the merge
+func (m MergeStorage) MergeMsg() string {
+	return m.MergeStorer.MergeMsg()
+}

--- a/storage/transactional/storage.go
+++ b/storage/transactional/storage.go
@@ -27,6 +27,7 @@ type basic struct {
 	*IndexStorage
 	*ShallowStorage
 	*ConfigStorage
+	*MergeStorage
 }
 
 // packageWriter implements storer.PackfileWriter interface over
@@ -49,6 +50,7 @@ func NewStorage(base, temporal storage.Storer) Storage {
 		IndexStorage:     NewIndexStorage(base, temporal),
 		ShallowStorage:   NewShallowStorage(base, temporal),
 		ConfigStorage:    NewConfigStorage(base, temporal),
+		MergeStorage:     NewMergeStorage(base, temporal),
 	}
 
 	pw, ok := temporal.(storer.PackfileWriter)


### PR DESCRIPTION
Enable getting the merge state from files MERGE_HEAD, MERGE_MODE, and MERGE_MSG that are created in .git/ during a merge.